### PR TITLE
DEV: Fix fontawesome v6 icon deprecation from `arrows-alt-h` to `left-right`

### DIFF
--- a/common/head_tag.html
+++ b/common/head_tag.html
@@ -31,7 +31,7 @@
       toolbar.addButton({
           id: "align_center_button",
           group: "extras",
-          icon: "arrows-alt-h",
+          icon: "left-right",
           perform: e => e.applySurround('<div align="center">\n\n', '\n\n</div>', 'align_center_text')
       });
   });


### PR DESCRIPTION

meta: https://meta.discourse.org/t/image-alignment-and-grid/271560/27

> Deprecation notice: The icon name “arrows-alt-h” has been updated to “left-right”. Please use the new name in your code. Old names will be removed in Q2 2025. [deprecation id: discourse.fontawesome-6-upgrade] [info: [We're upgrading our icons to Font Awesome 6!](https://meta.discourse.org/t/325349) ]